### PR TITLE
Added BaseUrl to avatar anchor

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,7 +17,7 @@
   </head>
   <body>
     <header class="app-header">
-      <a href="/"><img class="app-header-avatar" src="{{ .Site.BaseURL }}/avatar.jpg" alt="{{ .Site.Params.author | default "John Doe" }}" /></a>
+      <a href="{{ .Site.BaseURL }}"><img class="app-header-avatar" src="{{ .Site.BaseURL }}/avatar.jpg" alt="{{ .Site.Params.author | default "John Doe" }}" /></a>
       <h1>{{ .Site.Title }}</h1>
       <p>{{ .Site.Params.description | default "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula turpis sit amet elit pretium." }}</p>
       <div class="app-header-social">


### PR DESCRIPTION
This fixes a bug that clicking the avatar will bring you to the wrong URL if the site isn't deployed in the root path.