### PR TITLE
Style improvements

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -34,6 +34,7 @@ a {
 code {
   font-family: monospace,monospace;
   font-size: 1em;
+  color: rgba($light-color, .8);
 }
 
 pre {

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -27,7 +27,22 @@ a {
   }
 }
 
+// Browsers seem to use a smaller default font-size with monospaced code
+// blocks (like 80% of the size of normal text) and that looks pretty bad with
+// small inline code-blocks in the middle of normal text (mainly because of
+// the very noticeable difference in x-height). This CSS corrects that problem.
+code {
+  font-family: monospace,monospace;
+  font-size: 1em;
+}
+
 pre {
+  // A larger monospaced block of text (that isn't mixed with normal text)
+  // generally looks heavier than normal text with the same font size. For this
+  // reason using a smaller monospaced font size makes sense in this situation.
+  code {
+    font-size: .8em;
+  }
   overflow: auto;
 }
 

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -19,7 +19,7 @@ h1, h2, h3, h4, h5, h6 {
 
 a {
   color: $primary-color;
-  transition: color 0.8s;
+  transition: color 0.35s;
   text-decoration: none;
 
   &:hover {

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -19,11 +19,11 @@ h1, h2, h3, h4, h5, h6 {
 
 a {
   color: $primary-color;
+  transition: color 0.8s;
   text-decoration: none;
 
   &:hover {
     color: $lightest-color;
-    transition: color 0.8s;
   }
 }
 

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -46,3 +46,9 @@ pre {
   overflow: auto;
 }
 
+::selection {
+  background: rgba($light-color, .25);
+}
+::-moz-selection {
+  background: rgba($light-color, .25);
+}

--- a/assets/css/_extra.scss
+++ b/assets/css/_extra.scss
@@ -1,0 +1,2 @@
+// Do not add any CSS to this file in the theme sources.
+// This file can be overridden to add project-specific CSS.

--- a/assets/css/components/_posts_list.scss
+++ b/assets/css/components/_posts_list.scss
@@ -4,7 +4,9 @@
 
 .posts-list-item {
   list-style: none;
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.3);
+  &:not(:last-child) {
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.3);
+  }
   padding: 0.4em 0;
 }
 

--- a/assets/css/components/_tag.scss
+++ b/assets/css/components/_tag.scss
@@ -6,10 +6,10 @@
   border-radius: 0.2em;
   white-space: nowrap;
   background: rgba(255, 255, 255, 0.1);
-  transition: color 0.8s, background 0.8s;
+  transition: color 0.35s, background 0.35s;
 
   &:hover {
-    transition: color 0.8s;
+    transition: color 0.25s, background 0.05s;
     background: rgba(255, 255, 255, 0.3);
   }
 }

--- a/assets/css/components/_tag.scss
+++ b/assets/css/components/_tag.scss
@@ -6,7 +6,7 @@
   border-radius: 0.2em;
   white-space: nowrap;
   background: rgba(255, 255, 255, 0.1);
-  transition: background 0.8s;
+  transition: color 0.8s, background 0.8s;
 
   &:hover {
     transition: color 0.8s;

--- a/assets/css/components/_tag.scss
+++ b/assets/css/components/_tag.scss
@@ -9,6 +9,7 @@
   transition: background 0.8s;
 
   &:hover {
+    transition: color 0.8s;
     background: rgba(255, 255, 255, 0.3);
   }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,3 +14,6 @@ $primary-color: {{ .Site.Params.style.primaryColor | default "#57cc8a" }};
 @import 'components/posts_list';
 @import 'components/tag';
 
+// The last 'extra' import can optionally be overridden on a per project
+// basis by creating a <HUGO_PROJECT>/assets/css/_extra.scss file.
+@import 'extra';


### PR DESCRIPTION
- Make the font-size of `inline code` the same as that of the surrounding normal text (the browser default monospaced font size is smaller than the default normal font size)
- Changing selection color from browser default (typically a blueish one) to theme-font-color with 25% alpha
- Change link highlight color fade-out time: 0s -> 0.8s (the change preserves the fancy link animation of the post tags)
- Not drawing a dashed separator line after the last item in the post list
- Subtle highlight on `code` (almost unnoticeable, a bit darker color than normal text, ask me to remove it if it doesn't fit into your definition of minimal design)
- Allow the addition of extra project-specific CSS by creating a `<HUGO_PROJECT>/assets/css/_extra.scss` file.