### PR TITLE
Add a terms page instead of using the default list page for tags

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+  <article>
+    <h1>{{ .Title }}</h1>
+    <ul class="posts-list">
+      {{ range .Data.Terms.Alphabetical }}
+        <li class="posts-list-item">
+            <a class="posts-list-item-title" href="{{ .Page.Permalink }}">
+              {{ .Page.Title }}
+            </a> 
+            {{ .Count }}
+        </li>
+      {{ end }}
+    </ul>
+    {{ partial "pagination.html" $ }}
+  </article>
+{{ end }}


### PR DESCRIPTION
In the current version, navigating to [{BaseURL}/tags](https://themes.gohugo.io/theme/hugo-theme-m10c/tags) lists the tag pages as if they are articles, each with a reading time of zero and a creation date of Jan 1, 0001.
<img src="https://user-images.githubusercontent.com/51073176/59187552-c0522c00-8b86-11e9-9c4e-a4b72647b08d.png" alt="before" width="100"/>

This replaces the tags page with an alphabetic listing of tag pages, with an article count for each tag.
<img src="https://user-images.githubusercontent.com/51073176/59187557-c3e5b300-8b86-11e9-93b5-d23078c92af7.png" alt="after" width="100"/>

