### PR TITLE
limit image width

### DIFF
--- a/assets/css/components/_post.scss
+++ b/assets/css/components/_post.scss
@@ -7,6 +7,9 @@
     border-left: 0.4em solid rgba($primary-color, .8);
     padding-left: 1em;
   }
+  img {
+    max-width: 100%;
+  }
 }
 
 .post-meta {


### PR DESCRIPTION
Currently, large images are inserted as-is and would take as much horizontal space as needed. This especially breaks the layout for mobile. A simple `width: 100%` should keep that in check (already tried it out via `_extra.scss`)