### PR TITLE
Fix css typo in icon styling

### DIFF
--- a/assets/css/components/_icon.scss
+++ b/assets/css/components/_icon.scss
@@ -1,5 +1,5 @@
 .icon {
-  display: block-inline;
+  display: inline-block;
   width: 1em;
   height: 1em;
   vertical-align: -0.125em;


### PR DESCRIPTION
the **display:** property in _icon.scss should be '**inline-block**'
'**block-inline**' isn't a valid display option so it gets silently ignored, and defaults to '**inline**'.
This looks the same for svg icons, but can mess up the layout if you use any font icons, emoji, unicode, etc.

