### PR TITLE
add favicon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In your `config.toml` file, define the following variables in `params`:
 - `description`: Short description of the author
 - `avatar`: Path of file containing the author avatar image
 - `menu_item_separator`: Separator between each menu item. HTML allowed (default: " - ")
+- `favicon`: Absolute path of your favicon.ico file (default: "/favicon.ico")
 
 To add a menu item, add the following lines in `menu`:
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode | default "en-us" }}">
   <head>
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} // {{ .Site.Title }}{{ end }}</title>
-    <link rel="shortcut icon" href="{{ .Site.Params.favicon | default "favicon.ico" }}" />
+    <link rel="shortcut icon" href="{{ .Site.Params.favicon | default "/favicon.ico" }}" />
     <meta charset="utf-8" />
     {{ hugo.Generator }}
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode | default "en-us" }}">
   <head>
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} // {{ .Site.Title }}{{ end }}</title>
+    <link rel="shortcut icon" href="{{ .Site.Params.favicon | default "favicon.ico" }}" />
     <meta charset="utf-8" />
     {{ hugo.Generator }}
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
When deploying Hugo on non-root url, favicon is not found. This code let user configure favicon path in config.toml

[params]
   favicon = <absolute path from />favicon.ico