### PR TITLE
Rework mobile header

### DIFF
--- a/assets/css/components/_app.scss
+++ b/assets/css/components/_app.scss
@@ -24,17 +24,31 @@
   }
 }
 
-@media (min-width: 940px) {
+@media (max-width: 940px) {
   .app-header {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 20rem;
-    min-height: 100vh;
+    padding: 0.5em;
+    min-height: 9rem;
+    width: 100%;
+
+    h2 {
+      font-size: large;
+    }
+
+    p {
+      clear: both;
+      text-align: left;
+    }
+  }
+
+  .app-header-avatar {
+    max-width: 8rem;
+    max-height: 8rem;
+    border-radius: 100%;
+    border: .25rem solid $primary-color;
+    float: left;
   }
 
   .app-container {
-    max-width: 65rem;
-    margin-left: 20rem;
+    padding: 0.5rem;
   }
 }

--- a/assets/css/components/_app.scss
+++ b/assets/css/components/_app.scss
@@ -24,6 +24,21 @@
   }
 }
 
+@media (min-width: 940px) {
+  .app-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 20rem;
+    min-height: 100vh;
+  }
+
+  .app-container {
+    max-width: 65rem;
+    margin-left: 20rem;
+  }
+}
+
 @media (max-width: 940px) {
   .app-header {
     padding: 0.5em;


### PR DESCRIPTION
Mobile header was too bulky. I made a more minimized version. Up to you if you want to merge this, but personally I did some testing and I think it looks better on a phone screen. Thanks for making such an awesome theme!

Old:
<img width="417" alt="Screen Shot 2021-02-17 at 2 41 13 PM" src="https://user-images.githubusercontent.com/361546/108259027-a83df880-712e-11eb-82bf-a8bfa48c4f34.png">


New:

<img width="418" alt="Screen Shot 2021-02-17 at 2 41 26 PM" src="https://user-images.githubusercontent.com/361546/108259040-ad9b4300-712e-11eb-9cae-4ebfe46437c4.png">


Live look: https://clete2.com