### PR TITLE
Add explicit avatar height/width

### DIFF
--- a/assets/css/components/_app.scss
+++ b/assets/css/components/_app.scss
@@ -5,8 +5,8 @@
 }
 
 .app-header-avatar {
-  max-width: 15rem;
-  max-height: 15rem;
+  width: 15rem;
+  height: 15rem;
   border-radius: 100%;
   border: 0.5rem solid $primary-color;
 }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,7 +18,7 @@
   </head>
   <body>
     <header class="app-header">
-      <a href="{{ .Site.BaseURL }}"><img class="app-header-avatar" src="{{ .Site.Params.avatar | default "avatar.jpg" | relURL }}" alt="{{ .Site.Params.author | default "John Doe" }}" /></a>
+      <a href="{{ .Site.BaseURL }}"><img class="app-header-avatar" src="{{ .Site.Params.avatar | default "avatar.jpg" | relURL }}" alt="{{ .Site.Params.author | default "John Doe" }}" height="240" width="240" /></a>
       <h1>{{ .Site.Title }}</h1>
       {{- with .Site.Menus.main }}
       <nav class="app-header-menu">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,7 +18,7 @@
   </head>
   <body>
     <header class="app-header">
-      <a href="{{ .Site.BaseURL }}"><img class="app-header-avatar" src="{{ .Site.Params.avatar | default "avatar.jpg" | relURL }}" alt="{{ .Site.Params.author | default "John Doe" }}" height="240" width="240" /></a>
+      <a href="{{ .Site.BaseURL }}"><img class="app-header-avatar" src="{{ .Site.Params.avatar | default "avatar.jpg" | relURL }}" alt="{{ .Site.Params.author | default "John Doe" }}" /></a>
       <h1>{{ .Site.Title }}</h1>
       {{- with .Site.Menus.main }}
       <nav class="app-header-menu">


### PR DESCRIPTION
Seeing a few issues in [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fsqualr.us%2F&tab=mobile&hl=en) related to the avatar image size not being set and content shifting. Thoughts on the proposed changes?

![image](https://user-images.githubusercontent.com/1166426/109688331-03151e00-7b39-11eb-9e4e-3e9578a79ce3.png)

![image](https://user-images.githubusercontent.com/1166426/109688364-0ad4c280-7b39-11eb-9758-ac5e55d7cb09.png)
