### PR TITLE
Adding rel=me links to social links

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,7 +34,7 @@
       {{- with .Site.Params.social }}
       <div class="app-header-social">
         {{ range . }}
-          <a href="{{ .url }}" target="_blank" rel="noreferrer noopener">
+          <a href="{{ .url }}" target="_blank" rel="noreferrer noopener me">
             {{ partial "icon.html" (dict "ctx" $ "name" .icon "title" .name) }}
           </a>
         {{ end }}


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a fairly widely used standard for linking from one page that's about a person to their profiles on others. It's now used in a variety of Hugo and other static site generator blog themes.