### PR TITLE
Prefer `RelPermalink` for CSS file

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
     <meta name="author" content="{{ .Site.Params.author | default "John Doe" }}" />
     <meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Description }}{{ end }}" />
     {{ $style := resources.Get "css/main.scss" | resources.ExecuteAsTemplate "css/main.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint -}}
-    <link rel="stylesheet" href="{{ $style.Permalink }}" />
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 
     {{ template "_internal/google_analytics.html" . }}
     {{ template "_internal/twitter_cards.html" . }}


### PR DESCRIPTION
I'm deploying to firebase staging before production deployment.
However `Permalink` always points to production URL.
Then, How about to use `RelPermalink` for that?

Hugo version compatibility - Digging in https://github.com/gohugoio/hugo/releases?q=RelPermalink&expanded=true, at least `RelPermalink` provided since [v0.32](https://github.com/gohugoio/hugo/releases/tag/v0.32).
It will fit [current restriction](https://github.com/vaga/hugo-theme-m10c/blob/bd6e4228fdae3cf4a34e7c133ef528e8b5bf69d0/config.toml#L4).

Thanks for this beautiful theme!