### PR TITLE
Fixes wonky iOS font sizing in code blocks

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -35,6 +35,12 @@ code {
   font-family: monospace,monospace;
   font-size: 1em;
   color: rgba($light-color, .8);
+
+  // Fixes iOS font sizing anomaly
+  text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 
 pre {


### PR DESCRIPTION
This is currently what code blocks look like in iOS Safari:

![broken](https://user-images.githubusercontent.com/162998/211105019-74f9b14c-fbe9-4b83-bbe6-6c2e6c726c1a.png)

This PR fixes them so they look like:

![fixed](https://user-images.githubusercontent.com/162998/211105108-80eae6ec-7614-49a6-b7f7-c39497a79428.png)

More details about this issue and the fix can be found at adityatelange/hugo-PaperMod#828.