### PR TITLE
Initialise scss variables from hugo config values

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,8 +1,10 @@
-$darkest-color: {{ .Site.Params.style.darkestColor | default "#242930" }};
-$dark-color: {{ .Site.Params.style.darkColor | default "#353b43" }};
-$light-color: {{ .Site.Params.style.lightColor | default "#afbac4" }};
-$lightest-color: {{ .Site.Params.style.lightestColor | default "#ffffff" }};
-$primary-color: {{ .Site.Params.style.primaryColor | default "#57cc8a" }};
+@import "hugo:vars";
+
+$darkest-color: #242930 !default;
+$dark-color: #353b43 !default;
+$light-color: #afbac4 !default;
+$lightest-color: #ffffff !default;
+$primary-color: #57cc8a !default;
 
 @import 'base';
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -36,24 +36,24 @@ paginate = 8
 
   # Default theme
   #[params.style]
-  #  darkestColor = "#242930"
-  #  darkColor = "#353b43"
-  #  lightColor = "#afbac4"
-  #  lightestColor = "#ffffff"
-  #  primaryColor = "#57cc8a"
+  #  darkest_color = "#242930"
+  #  dark_color = "#353b43"
+  #  light_color = "#afbac4"
+  #  lightest_color = "#ffffff"
+  #  primary_color = "#57cc8a"
 
   # Green theme
   #[params.style]
-  #  darkestColor = "#315659"
-  #  darkColor = "#253031"
-  #  lightColor = "#96a879"
-  #  lightestColor = "#fff"
-  #  primaryColor = "#dad865"
+  #  darkest_color = "#315659"
+  #  dark_color = "#253031"
+  #  light_color = "#96a879"
+  #  lightest_color = "#fff"
+  #  primary_color = "#dad865"
 
   # Red theme
   #[params.style]
-  #  darkestColor = "#d35050"
-  #  darkColor = "#212121"
-  #  lightColor = "#d6d6d6"
-  #  lightestColor = "#d3d3d3"
-  #  primaryColor = "#ffffff"
+  #  darkest_color = "#d35050"
+  #  dark_color = "#212121"
+  #  light_color = "#d6d6d6"
+  #  lightest_color = "#d3d3d3"
+  #  primary_color = "#ffffff"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="author" content="{{ .Site.Params.author | default "John Doe" }}" />
     <meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Description }}{{ end }}" />
-    {{ $style := resources.Get "css/main.scss" | resources.ExecuteAsTemplate "css/main.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint -}}
+    {{ $style := resources.Get "css/main.scss" | resources.ExecuteAsTemplate "css/main.scss" . | resources.ToCSS (dict "vars" site.Params.style) | resources.Minify | resources.Fingerprint -}}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 
     {{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
Following the information from [this guide](https://discourse.gohugo.io/t/initialize-sass-variables-from-hugo-templates/42053), specifically the section that uses the built-in LibSass transpiler to avoid adding dependencies.

I had to change the config style variables to use snake_case as hugo transforms keys to lowercase (which would have resulted in darkestcolor when imported in scss) and hyphens can't be included as go identifiers can't contain hyphens