### PR TITLE
fix: remove flex capability in .post-meta div element to allow tag-list line breaks

### DIFF
--- a/assets/css/components/_post.scss
+++ b/assets/css/components/_post.scss
@@ -3,7 +3,10 @@
 }
 
 .post-meta > div {
+  display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 0.2em;
   font-size: 0.8em;
 
   > .icon {

--- a/assets/css/components/_post.scss
+++ b/assets/css/components/_post.scss
@@ -3,7 +3,6 @@
 }
 
 .post-meta > div {
-  display: flex;
   align-items: center;
   font-size: 0.8em;
 


### PR DESCRIPTION
Closes: #114

Hi there 👋,
removing the `flex` capability form `.post-meta` fixes issue #114 for me. 
Please have a look if the suggested change does not break anything that I might not have been aware of!

Here a demo with the [exampleSite](https://github.com/vaga/hugo-theme-m10c/tree/master/exampleSite):


![tag-list-line-break-video](https://github.com/vaga/hugo-theme-m10c/assets/104433967/031d84c4-b830-4f36-93c4-95ff292e2139)

