### PR TITLE
feat: use relative path for internal links

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,7 +21,7 @@
   </head>
   <body>
     <header class="app-header">
-      <a href="{{ .Site.BaseURL }}"><img class="app-header-avatar" src="{{ .Site.Params.avatar | default "avatar.jpg" | relURL }}" alt="{{ .Site.Params.author | default "John Doe" }}" /></a>
+      <a href="{{ "" | relURL }}"><img class="app-header-avatar" src="{{ .Site.Params.avatar | default "avatar.jpg" | relURL }}" alt="{{ .Site.Params.author | default "John Doe" }}" /></a>
       <span class="app-header-title">{{ .Site.Title }}</span>
       {{- with .Site.Menus.main }}
       <nav class="app-header-menu">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,7 @@
     <ul class="posts-list">
       {{ range where .Paginator.Pages "Type" "!=" "page" }}
         <li class="posts-list-item">
-          <a class="posts-list-item-title" href="{{ .Permalink }}">{{ .Title }}</a>
+          <a class="posts-list-item-title" href="{{ .RelPermalink }}">{{ .Title }}</a>
           <span class="posts-list-item-description">
             {{ partial "icon.html" (dict "ctx" $ "name" "calendar") }}
             {{ .PublishDate.Format "Jan 2, 2006" }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
           {{ partial "icon.html" (dict "ctx" $ "name" "tag") }}
           {{- range . -}}
             {{ with $.Site.GetPage (printf "/%s/%s" "tags" . ) }}
-              <a class="tag" href="{{ .Permalink }}">{{ .Title }}</a>
+              <a class="tag" href="{{ .RelPermalink }}">{{ .Title }}</a>
             {{- end }}
           {{- end }}
         </div>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
       {{ range .Data.Terms.ByCount }}
         <li class="tags-list-item">
             {{ partial "icon.html" (dict "ctx" $ "name" "tag") }}
-            <a class="tags-list-item-title" href="{{ .Page.Permalink }}">
+            <a class="tags-list-item-title" href="{{ .Page.RelPermalink }}">
               ({{ .Count }})
               {{ .Page.Title }}
             </a>


### PR DESCRIPTION
This PR follows the same principle as https://github.com/vaga/hugo-theme-m10c/pull/95, but for internal navigation links (post lists, tag pages, and home links).

Thanks for the nice theme:)