### PR TITLE
Replace APIs deprecated in Hugo 0.156/0.158: `.Site.LanguageCode` and `.Site.Data`

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.LanguageCode | default "en-us" }}">
+<html lang="{{ .Site.Language.Locale }}">
   <head>
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} // {{ .Site.Title }}{{ end }}</title>
     <link rel="shortcut icon" href="{{ .Site.Params.favicon | default "/favicon.ico" }}" />

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,5 +1,6 @@
-{{- if isset .ctx.Site.Data.m10c.icons .name -}}
-  {{ safeHTML (index .ctx.Site.Data.m10c.icons .name) }}
+{{- $icons := index hugo.Data "m10c" "icons" -}}
+{{- if isset $icons .name -}}
+  {{ safeHTML (index $icons .name) }}
 {{- else -}}
 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-link">
   <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>

--- a/theme.toml
+++ b/theme.toml
@@ -3,6 +3,7 @@ license = "MIT"
 licenselink = "https://github.com/vaga/hugo-theme-m10c/blob/master/LICENSE.md"
 description = "A minimalistic (m10c) theme for bloggers"
 homepage = "https://github.com/vaga/hugo-theme-m10c"
+min_version = "0.158.0"
 tags = ["blog", "minimalistic", "minimal", "responsive", "dark"]
 features = [
   "minimalistic blog",


### PR DESCRIPTION
`.Site.LanguageCode` (deprecated in v0.158.0) and `.Site.Data` (deprecated in v0.156.0) each emit a build warning for every site using the theme, regardless of the site's own configuration, which is confusing until the user realizes it's the theme that is not up-to-date.

This PR addresses the deprecation, by using the new fields and APIs.

Due to the use of the new APIs, the minimum version to use the module was also updated.

Under the hood, `.Site.Language.Locale`  already implements logic to retrieve the locale from other properties if it's empty, so I also removed the `default "en-us"` branch in order to let that logic be followed.

FIxes: #133 